### PR TITLE
Build Settings for 'Release' paths need updating

### DIFF
--- a/RNUploader/RNUploader.xcodeproj/project.pbxproj
+++ b/RNUploader/RNUploader.xcodeproj/project.pbxproj
@@ -215,6 +215,8 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../../node_modules/react-native/React/**",
+					"$(SRCROOT)/node_modules/react-native/React/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
The build settings for `Release` did not include the complete Header Search Paths.  This corrects the project settings.
